### PR TITLE
Refactor role checks and approval validation

### DIFF
--- a/app/Http/Controllers/OrderController.php
+++ b/app/Http/Controllers/OrderController.php
@@ -215,7 +215,7 @@ class OrderController extends Controller
 
             switch ($order->status) {
                 case DBConstanst::ORDER_STATUS_PENDING:
-                    if (Auth::user()->role !== 'finance' && Auth::user()->role !== 'finance_head' && Auth::user()->role !== 'super_admin') {
+                    if (!Auth::user()->hasAnyRole(['finance', 'finance_head', 'super_admin'])) {
                         DB::rollBack();
                         return redirect()->route('penjualan.index')->with('error', 'Role Anda tidak memiliki akses untuk melakukan approval pada order ini.');
                     }
@@ -245,7 +245,7 @@ class OrderController extends Controller
                     }
                     break;
                 case DBConstanst::ORDER_STATUS_AR_CHECKED:
-                    if (Auth::user()->role !== 'owner' && Auth::user()->role !== 'super_admin') {
+                    if (!Auth::user()->hasAnyRole(['owner', 'super_admin'])) {
                         DB::rollBack();
                         return redirect()->route('penjualan.index')->with('error', 'Role Anda tidak memiliki akses untuk melakukan approval pada order ini.');
                     }
@@ -263,7 +263,7 @@ class OrderController extends Controller
                     break;
                 case DBConstanst::ORDER_STATUS_AR_APPROVED:
                 case DBConstanst::ORDER_STATUS_PAYMENT_APPROVED:
-                    if (Auth::user()->role !== 'warehouse' && Auth::user()->role !== 'warehouse_head' && Auth::user()->role !== 'super_admin') {
+                    if (!Auth::user()->hasAnyRole(['warehouse', 'warehouse_head', 'super_admin'])) {
                         DB::rollBack();
                         return redirect()->route('penjualan.index')->with('error', 'Role Anda tidak memiliki akses untuk melakukan approval pada order ini.');
                     }
@@ -279,7 +279,7 @@ class OrderController extends Controller
                     ]);
                     break;
                 case DBConstanst::ORDER_STATUS_STOCK_AVAILABLE:
-                    if (Auth::user()->role !== 'admin' && Auth::user()->role !== 'super_admin') {
+                    if (!Auth::user()->hasAnyRole(['admin', 'super_admin'])) {
                         DB::rollBack();
                         return redirect()->route('penjualan.index')->with('error', 'Role Anda tidak memiliki akses untuk melakukan approval pada order ini.');
                     }
@@ -296,7 +296,7 @@ class OrderController extends Controller
 
                     break;
                 case DBConstanst::ORDER_STATUS_STOCK_UNAVAILABLE:
-                    if (Auth::user()->role !== 'admin' && Auth::user()->role !== 'super_admin') {
+                    if (!Auth::user()->hasAnyRole(['admin', 'super_admin'])) {
                         DB::rollBack();
                         return redirect()->route('penjualan.index')->with('error', 'Role Anda tidak memiliki akses untuk melakukan approval pada order ini.');
                     }
@@ -313,7 +313,7 @@ class OrderController extends Controller
                     break;
                 case DBConstanst::ORDER_STATUS_REQUESTED_TO_SUPPLIER:
                 case DBConstanst::ORDER_STATUS_SENT_TO_CUSTOMER:
-                    if (Auth::user()->role !== 'admin' && Auth::user()->role !== 'super_admin') {
+                    if (!Auth::user()->hasAnyRole(['admin', 'super_admin'])) {
                         DB::rollBack();
                         return redirect()->route('penjualan.index')->with('error', 'Role Anda tidak memiliki akses untuk melakukan approval pada order ini.');
                     }
@@ -356,7 +356,7 @@ class OrderController extends Controller
 
             // Hanya order dengan status PENDING atau AR_APPROVED yang bisa direject
             if ($order->status == DBConstanst::ORDER_STATUS_PENDING) {
-                if (Auth::user()->role !== 'finance' && Auth::user()->role !== 'finance_head' && Auth::user()->role !== 'admin') {
+                if (!Auth::user()->hasAnyRole(['finance', 'finance_head', 'admin', 'super_admin'])) {
                     return redirect()->route('penjualan.index')->with('error', 'Role Anda tidak memiliki akses untuk melakukan approval pada order ini.');
                 }
                 $order->status = DBConstanst::ORDER_STATUS_REJECTED;
@@ -375,7 +375,11 @@ class OrderController extends Controller
                 ]);
             }
 
-            if (DBConstanst::ORDER_STATUS_AR_APPROVED && DBConstanst::ORDER_STATUS_PAYMENT_APPROVED) {
+            if ($order->status == DBConstanst::ORDER_STATUS_AR_APPROVED || $order->status == DBConstanst::ORDER_STATUS_PAYMENT_APPROVED) {
+                if (!Auth::user()->hasAnyRole(['warehouse', 'warehouse_head', 'super_admin'])) {
+                    return redirect()->route('penjualan.index')->with('error', 'Role Anda tidak memiliki akses untuk melakukan approval pada order ini.');
+                }
+
                 $order->status = DBConstanst::ORDER_STATUS_STOCK_UNAVAILABLE;
                 $order->save();
                 OrderApprovalLog::create([

--- a/app/Service/ApprovalService.php
+++ b/app/Service/ApprovalService.php
@@ -14,9 +14,7 @@ class ApprovalService
 {
     public function validateApproval($approvalId)
     {
-        $data = Approval::find($approvalId)->where('status', 0)->first();
-        if(empty($data)) return false;
-        return true;
+        return Approval::where('id', $approvalId)->where('status', 0)->exists();
 
         /* $user = User::find($data->requestor_id);
         $karyawan = Karyawan::find($user->karyawan_id);

--- a/resources/js/Pages/Penjualan/History.vue
+++ b/resources/js/Pages/Penjualan/History.vue
@@ -2,7 +2,6 @@
 import { usePage } from '@inertiajs/vue3';
 
 const page = usePage();
-const role = page.props.auth?.role[0] || 'guest';
 
 const metodePembayaran = [
   'Cash',
@@ -517,43 +516,44 @@ export default {
       }
     },
     handleShowButton(status) {
-      const role = this.$page.props.auth?.role[0] || 'guest';
+      const roles = this.$page.props.auth?.role || [];
+      const hasRole = (...required) => required.some(r => roles.includes(r));
       this.approval.showApprove = false;
       this.approval.showReject = false;
       switch (status.toString()) {
         case "0":
-          if (role == "finance" || role == "finance_head" || role == "super_admin") {
+          if (hasRole('finance', 'finance_head', 'super_admin')) {
             this.approval.showApprove = true;
             this.approval.showReject = true;
           }
           return "Setujui Permintaan";
         case "-1":
-          if (role == "owner" || role == "super_admin") {
+          if (hasRole('owner', 'super_admin')) {
             this.approval.showApprove = true;
             this.approval.showReject = true;
           }
           return "Setujui Permintaan AR";
         case "1":
         case "2":
-          if (role == "warehouse" || role == "warehouse_head" || role == "super_admin") {
+          if (hasRole('warehouse', 'warehouse_head', 'super_admin')) {
             this.approval.showApprove = true;
             this.approval.showReject = true;
           }
           return "Stock Tersedia";
         case "3":
-          if (role == "admin" || role == "super_admin") {
+          if (hasRole('admin', 'super_admin')) {
             console.log("showApprove");
             this.approval.showApprove = true;
           }
           return "Tandai Sedang Dikirim";
         case "4":
-          if (role == "admin" || role == "super_admin") {
+          if (hasRole('admin', 'super_admin')) {
             this.approval.showApprove = true;
           }
           return "Tandai Sedang Proses Supplier";
         case "5":
         case "6":
-          if (role == "admin" || role == "super_admin") {
+          if (hasRole('admin', 'super_admin')) {
             this.approval.showApprove = true;
           }
           return "Tandai Sudah Diterima";


### PR DESCRIPTION
## Summary
- Fix approval validation to properly check pending records
- Refactor role checks in order approvals and rejections
- Handle multi-role access when showing approval buttons on order history page

## Testing
- `npm run build`
- `php artisan test` *(fails: SQLSTATE[HY000] [2002] Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68bfee4b1fb083239d4910eda6fc85ad